### PR TITLE
Swap FAQs and "Who can I talk to" on offender page

### DIFF
--- a/app/views/offenders/show.html.haml
+++ b/app/views/offenders/show.html.haml
@@ -44,6 +44,36 @@
 
 %section.row
   .col.s10.offset-s1
+    %h2.app-typography--header-2 Frequently Asked Questions
+
+    - dropdown_key = 'faqs.prison_jail.dropdowns.how_earliest_release_date_change'
+    = render_component 'dropdown', title: t("#{dropdown_key}.title") do
+      .app-faq-item
+        = faq_format(t("#{dropdown_key}.body"))
+
+    = render_component 'dropdown', title: 'How can I stay informed about where the offender is?' do
+      %h3.app-typography--body-1
+        %strong Oregon VINE
+      %p
+        VINE is an automated notification system. For example, VINE will call,
+        text, and/or email you if there is a change in custody status.
+      = render_component 'button', to: vine_path(@offender[:sid]) do
+        VINE website
+        %i.material-icons open_in_new
+
+      %h3.app-typography--body-1
+        %strong Oregon Prison Release Notification
+      %p
+        The Oregon Parole Board can notify you 90 days prior to an inmate's
+        release and help you get a No Contact order added to an inmate's
+        conditions of Post-Prison Supervision.
+      - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
+      = render_component 'button', to: pps_form do
+        Sign Up Form
+        %i.material-icons open_in_new
+
+%section.row
+  .col.s10.offset-s1
     %h2.app-typography--header-2 Who can I talk to?
 
     = render_component 'avatar_list_item',
@@ -103,32 +133,3 @@
       %p The victim service programs offered by the Oregon Department of Corrections
       %p Questions about VINE
 
-%section.row
-  .col.s10.offset-s1
-    %h2.app-typography--header-2 Frequently Asked Questions
-
-    - dropdown_key = 'faqs.prison_jail.dropdowns.how_earliest_release_date_change'
-    = render_component 'dropdown', title: t("#{dropdown_key}.title") do
-      .app-faq-item
-        = faq_format(t("#{dropdown_key}.body"))
-
-    = render_component 'dropdown', title: 'How can I stay informed about where the offender is?' do
-      %h3.app-typography--body-1
-        %strong Oregon VINE
-      %p
-        VINE is an automated notification system. For example, VINE will call,
-        text, and/or email you if there is a change in custody status.
-      = render_component 'button', to: vine_path(@offender[:sid]) do
-        VINE website
-        %i.material-icons open_in_new
-
-      %h3.app-typography--body-1
-        %strong Oregon Prison Release Notification
-      %p
-        The Oregon Parole Board can notify you 90 days prior to an inmate's
-        release and help you get a No Contact order added to an inmate's
-        conditions of Post-Prison Supervision.
-      - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
-      = render_component 'button', to: pps_form do
-        Sign Up Form
-        %i.material-icons open_in_new


### PR DESCRIPTION
For a quick fix, swapping FAQs and "Who can I talk to" sections. Though I can't test it yet, so pull request seemed like a safe option