### PR TITLE
Add probation page skeleton

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tdooner/oos-mechanizer.git
-  revision: 39de5a27fdbc90d85b1a9402cb05f005bdf15802
+  revision: 54c4b6ec3281d5b05da745dde2c901654544faf3
   specs:
     oos_mechanizer (0.1.1)
       mechanize (~> 2.7.5)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -103,6 +103,41 @@ strong {
   }
 }
 
+.app-todo {
+  position: relative;
+
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  &::before {
+    display: block;
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border: 3px dashed rgba(#c069ff, 0.6);
+    top: 0;
+    left: 0;
+    z-index: 0;
+  }
+
+  &::after {
+    display: block;
+    content: 'TODO';
+    position: absolute;
+    top: 0;
+    right: 0;
+    color: #fff;
+    background-color: rgba(#c069ff, 0.6);
+    font-size: 10px;
+    padding: 2px;
+    margin-top: 3px;
+    margin-right: 3px;
+  }
+}
+
 .app-typography--display-1 {
   @extend %app-typography--display-1;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :set_variables
   before_action :clear_notification_id
   before_action :set_raven_context
+  before_action :set_current_user
 
   private
 
@@ -12,7 +13,7 @@ class ApplicationController < ActionController::Base
     @mixpanel_token = Rails.application.config.mixpanel_token
   end
 
-  def current_user
+  def set_current_user
     @current_user ||= if session[:user_id]
                         User.find(session[:user_id])
                       end

--- a/app/controllers/court_case_subscriptions_controller.rb
+++ b/app/controllers/court_case_subscriptions_controller.rb
@@ -25,20 +25,20 @@ class CourtCaseSubscriptionsController < ApplicationController
   def subscription_params
     params.fetch(:court_case_subscription, {})
       .permit(:case_number)
-      .merge(user_id: current_user.id)
+      .merge(user_id: @current_user.id)
   end
 
   def require_edit_permission
     # TODO: extract this into a superclass to DRY it up
-    unless current_user
+    unless @current_user
       flash[:error] = 'You must be logged in to view this page.'
       return redirect_to new_sessions_path(next_path: request.path)
     end
 
-    return if current_user.is_admin
+    return if @current_user.is_admin
 
     user = User.find(params[:user_id])
-    if user != current_user
+    if user != @current_user
       flash[:error] = 'You do not have permission to view this page.'
       return redirect_to home_path
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,14 +1,14 @@
 class HomeController < ApplicationController
   def splash
-    return redirect_to home_path if current_user
+    return redirect_to home_path if @current_user
 
     render layout: 'splash'
   end
 
   def home
-    return redirect_to root_path unless current_user
+    return redirect_to root_path unless @current_user
 
-    @subscriptions = CourtCaseSubscription.where(user: current_user)
+    @subscriptions = CourtCaseSubscription.where(user: @current_user)
   end
 
   def set_tracking

--- a/app/controllers/offenders_controller.rb
+++ b/app/controllers/offenders_controller.rb
@@ -10,7 +10,7 @@ class OffendersController < ApplicationController
     elsif offender_params[:sid].present?
       # when searching for a SID, just go to /offenders/<sid> and let that page
       # do the search
-      redirect_to offender_path(offender_params[:sid])
+      redirect_to offender_offenders_path(:oregon, offender_params[:sid])
     elsif params[:error]
       # if this page has an "error" query param then don't attempt a search and
       # just show that error
@@ -52,7 +52,13 @@ class OffendersController < ApplicationController
   end
 
   def show
-    @offender = OffenderScraper.offender_details(params[:id])
+    @offender =
+      case params[:jurisdiction].to_sym
+      when :oregon
+        OffenderScraper.offender_details(params[:id])
+      when :dcj
+        DcjClient.new.offender_details(sid: params[:id])
+      end
 
     if @offender.nil?
       redirect_to offenders_path(error: 'no_offender_found', error_sid: params[:id])

--- a/app/controllers/offenders_controller.rb
+++ b/app/controllers/offenders_controller.rb
@@ -1,11 +1,11 @@
 class OffendersController < ApplicationController
   def index
-    if offender_params[:last_name].present? && offender_params[:dcj_sid].present? &&
+    if offender_params[:dcj_last_name].present? && offender_params[:dcj_sid].present? &&
         Rails.application.config.flipper[:dcj_search].enabled?
       # DCJ search requires last_name and SID for now :(
       @results = [DcjClient.new.offender_details(
         sid: offender_params[:dcj_sid],
-        last_name: offender_params[:last_name]
+        last_name: offender_params[:dcj_last_name]
       )]
     elsif offender_params[:sid].present?
       # when searching for a SID, just go to /offenders/<sid> and let that page

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,21 +2,21 @@ class UsersController < ApplicationController
   before_action :require_edit_permission
 
   def edit
-    @subscriptions = CourtCaseSubscription.where(user_id: current_user)
+    @subscriptions = CourtCaseSubscription.where(user_id: @current_user)
   end
 
   private
 
   def require_edit_permission
-    unless current_user
+    unless @current_user
       flash[:error] = 'You must be logged in to view this page.'
       return redirect_to new_sessions_path(next_path: request.path)
     end
 
-    return if current_user.is_admin
+    return if @current_user.is_admin
 
     user = User.find(params[:id])
-    if user != current_user
+    if user != @current_user
       flash[:error] = 'You do not have permission to view this page.'
       return redirect_to home_path
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,9 +22,9 @@ module ApplicationHelper
 
   # Given a phone number like '+11234567890', returns '(123) 456-7890'
   def format_phone(phone_number)
-    local_number = phone_number.gsub(/^\+1/, '')
+    local_number = phone_number.gsub(/^\+1/, '').gsub(/-/, '')
 
-    "(#{local_number[0..2]}) #{local_number[3..5]}-#{local_number[6..9]}"
+    "(#{local_number[0..2]}) #{local_number[3..5]}-#{local_number[6..-1]}"
   end
 
   # Handles the logic for whether to link to the offender page directly, or to

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,11 @@ module ApplicationHelper
     @current_user
   end
 
+  # TODO: Remove this wrapper by just calling the correct path everywhree
+  def offender_path(id, jurisdiction = :oregon)
+    offender_offenders_path(id, jurisdiction)
+  end
+
   # Reorders a name if it contains a comma. E.g. given "Smith, Joe" will return
   # "Joe Smith"
   def name_reorderer(full_name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,4 @@
 module ApplicationHelper
-  def current_user
-    @current_user
-  end
-
   # TODO: Remove this wrapper by just calling the correct path everywhree
   def offender_path(id, jurisdiction = :oregon)
     offender_offenders_path(id, jurisdiction)

--- a/app/lib/offender_grouper.rb
+++ b/app/lib/offender_grouper.rb
@@ -24,7 +24,12 @@ class OffenderGrouper
           Raven.capture_message("DOB for SID #{sid} results not all identical!")
         end
 
-        first, middle, last, dob = results[0].values_at(:first, :middle, :last, :dob)
+        if results.map { |o| o[:jurisdiction] }.uniq.length > 1
+          Raven.capture_message("Jurisdiction for SID #{sid} results not all identical!")
+        end
+
+        first, middle, last, dob, jurisdiction =
+          results[0].values_at(:first, :middle, :last, :dob, :jurisdiction)
         aliases = results[1..-1].map do |r|
           format_name(r[:first], r[:middle], r[:last])
         end
@@ -34,6 +39,7 @@ class OffenderGrouper
           full_name: format_name(first, middle, last),
           dob: dob,
           aliases: aliases,
+          jurisdiction: jurisdiction,
         }
     end
   end

--- a/app/lib/offender_scraper.rb
+++ b/app/lib/offender_scraper.rb
@@ -7,7 +7,9 @@ module OffenderScraper
   #   a search results page that can take a couple seconds to load.
   def self.search_by_name(first_name, last_name)
     searcher = OosMechanizer::Searcher.new
-    searcher.each_result(first_name: first_name, last_name: last_name).to_a
+    searcher.each_result(first_name: first_name, last_name: last_name).map do |result|
+      result.merge(jurisdiction: :oregon)
+    end
   end
 
   # @return Hash? Information about the offender, if found. This method is

--- a/app/lib/offender_scraper.rb
+++ b/app/lib/offender_scraper.rb
@@ -16,11 +16,15 @@ module OffenderScraper
     cached = OffenderSearchCache.find_by(offender_sid: sid)
 
     if cached
-      cached.data.symbolize_keys
+      cached.data.symbolize_keys.merge(
+        jurisdiction: :oregon
+      )
     else
       data = self.fetch_offender_details(sid)
 
       return nil if data.nil?
+
+      data[:jurisdiction] = :oregon
 
       OffenderSearchCache
         .unscoped

--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -1,10 +1,10 @@
 .row
   .col.s11.offset-s1
-    %h2.app-typography--header-1 Hello #{current_user.email}
+    %h2.app-typography--header-1 Hello #{@current_user.email}
     %p
       You are logged in.
 
-    %h3.app-typography--header-2 Court Case Subscriptions (#{link_to 'Edit', edit_user_path(current_user)})
+    %h3.app-typography--header-2 Court Case Subscriptions (#{link_to 'Edit', edit_user_path(@current_user)})
     %ul
       - @subscriptions.each do |subscription|
         = link_to subscription.case_number, subscription_path(subscription)

--- a/app/views/home/splash.html.haml
+++ b/app/views/home/splash.html.haml
@@ -1,4 +1,4 @@
-- if current_user
+- if @current_user
   = render 'user'
 - else
   = render 'logged_out'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,9 +20,9 @@
               %h1.app-header__title= render_component 'logo'
           - if feature_enabled?(:log_in)
             .col.s12.m6.app-feature-flagged
-              - if current_user
-                = link_to edit_user_path(current_user), class: 'app-header__link' do
-                  .app-header__title= current_user.email
+              - if @current_user
+                = link_to edit_user_path(@current_user), class: 'app-header__link' do
+                  .app-header__title= @current_user.email
                 &middot;
                 = link_to sessions_path, method: :delete, class: 'app-header__link' do
                   %div.app-header__title Log Out

--- a/app/views/layouts/splash.html.haml
+++ b/app/views/layouts/splash.html.haml
@@ -20,9 +20,9 @@
 
           - if feature_enabled?(:log_in)
             .col.s12.m6.offset-m1.app-feature-flagged
-              - if current_user
+              - if @current_user
                 = link_to '#', class: 'app-header__link' do
-                  .app-header__title--splash= current_user.email
+                  .app-header__title--splash= @current_user.email
                 &middot;
                 = link_to sessions_path, method: :delete, class: 'app-header__link' do
                   %div.app-header__title--splash Log Out

--- a/app/views/offenders/_faq_prison_jail.html.haml
+++ b/app/views/offenders/_faq_prison_jail.html.haml
@@ -1,0 +1,26 @@
+- dropdown_key = 'faqs.prison_jail.dropdowns.how_earliest_release_date_change'
+= render_component 'dropdown', title: t("#{dropdown_key}.title") do
+  .app-faq-item
+    = faq_format(t("#{dropdown_key}.body"))
+
+= render_component 'dropdown', title: 'How can I stay informed about where the offender is?' do
+  %h3.app-typography--body-1
+    %strong Oregon VINE
+  %p
+    VINE is an automated notification system. For example, VINE will call,
+    text, and/or email you if there is a change in custody status.
+  = render_component 'button', to: vine_path(@offender[:sid]) do
+    VINE website
+    %i.material-icons open_in_new
+
+  %h3.app-typography--body-1
+    %strong Oregon Prison Release Notification
+  %p
+    The Oregon Parole Board can notify you 90 days prior to an inmate's
+    release and help you get a No Contact order added to an inmate's
+    conditions of Post-Prison Supervision.
+  - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
+  = render_component 'button', to: pps_form do
+    Sign Up Form
+    %i.material-icons open_in_new
+

--- a/app/views/offenders/_faq_probation.html.haml
+++ b/app/views/offenders/_faq_probation.html.haml
@@ -1,0 +1,4 @@
+.app-todo
+  = render_component 'dropdown', title: 'What is probation?' do
+    .app-faq-item
+      Here is where we describe what probation is.

--- a/app/views/offenders/_faq_probation.html.haml
+++ b/app/views/offenders/_faq_probation.html.haml
@@ -1,4 +1,7 @@
-.app-todo
-  = render_component 'dropdown', title: 'What is probation?' do
-    .app-faq-item
-      Here is where we describe what probation is.
+= render_component 'dropdown', title: t('offender.probation_faq_1_title') do
+  .app-faq-item
+    = faq_format(t('offender.probation_faq_1'))
+
+= render_component 'dropdown', title: t('offender.probation_faq_2_title') do
+  .app-faq-item
+    = faq_format(t('offender.probation_faq_2'))

--- a/app/views/offenders/_who_prison_jail.html.haml
+++ b/app/views/offenders/_who_prison_jail.html.haml
@@ -1,57 +1,63 @@
-= render_component 'avatar_list_item',
-  caption: t('offender.robyn_title'),
-  name: t('offender.robyn'),
-  image: image_path('robyn.jpg')
-
-= render_component 'dropdown', title: t('offender.contact_info', name: 'Robyn') do
-  %ul.app-contact-list
-    %li
-      = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
-        %i.material-icons.app-contact-list__icon phone
-        %span.app-contact-list__primary-description
-          (503) 945-0907
-    %li
-      = link_to 'mailto:DLParoleBoardVictimNotify@doc.state.or.us', class: 'app-contact-list__link' do
-        %i.material-icons.app-contact-list__icon email
-        %span.app-contact-list__primary-description
-          DLParoleBoardVictimNotify@doc.state.or.us
-
-= render_component 'dropdown', title: t('offender.what_talk_about', name: 'Robyn') do
-  %p How to stay informed
-  %p What these notifications mean
-  %p Why the release date changes
-  %p Will there be a parole hearing I can speak at
-  %p Release plans and safety planning
-  %p Discuss terms of supervision and no contact orders
-  %p When and where an offender will be released
-  %p And more…
+%section.row
+  .col.s10.offset-s1
+    %h2.app-typography--header-2 Who can I talk to?
 
 .row
-.col.s10.offset-s1
-= render_component 'avatar_list_item',
-  caption: t('offender.saydyie_title'),
-  image: image_path('saydyie.jpg'),
-  name: t('offender.saydyie')
+  .col.s10.offset-s1
+    = render_component 'avatar_list_item',
+      caption: t('offender.robyn_title'),
+      name: t('offender.robyn'),
+      image: image_path('robyn.jpg')
 
-= render_component 'dropdown', title: t('offender.contact_info', name: 'Saydyie') do
-  %ul.app-contact-list
-    %li
-      = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
-        %i.material-icons.app-contact-list__icon phone
-        %span.app-contact-list__primary-description
-          (503) 934-1113
-    %li
-      = link_to 'mailto:VictimServicesProgram@doc.state.or.us', class: 'app-contact-list__link' do
-        %i.material-icons.app-contact-list__icon email
-        %span.app-contact-list__primary-description
-          VictimServicesProgram@doc.state.or.us
+    = render_component 'dropdown', title: t('offender.contact_info', name: 'Robyn') do
+      %ul.app-contact-list
+        %li
+          = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
+            %i.material-icons.app-contact-list__icon phone
+            %span.app-contact-list__primary-description
+              (503) 945-0907
+        %li
+          = link_to 'mailto:DLParoleBoardVictimNotify@doc.state.or.us', class: 'app-contact-list__link' do
+            %i.material-icons.app-contact-list__icon email
+            %span.app-contact-list__primary-description
+              DLParoleBoardVictimNotify@doc.state.or.us
 
-= render_component 'dropdown', title: t('offender.what_talk_about', name: 'Saydyie') do
-  %p General public information about the offender
-  %p General information regarding misconducts the offender has received
-  %p Programs offered and general information on if the inmate is participating in programming
-  %p Location and institution movement of the offender
-  %p Resources for victims and victim family members
-  %p The victim service programs offered by the Oregon Department of Corrections
-  %p Questions about VINE
+    = render_component 'dropdown', title: t('offender.what_talk_about', name: 'Robyn') do
+      %p How to stay informed
+      %p What these notifications mean
+      %p Why the release date changes
+      %p Will there be a parole hearing I can speak at
+      %p Release plans and safety planning
+      %p Discuss terms of supervision and no contact orders
+      %p When and where an offender will be released
+      %p And more…
+
+.row
+  .col.s10.offset-s1
+    = render_component 'avatar_list_item',
+      caption: t('offender.saydyie_title'),
+      image: image_path('saydyie.jpg'),
+      name: t('offender.saydyie')
+
+    = render_component 'dropdown', title: t('offender.contact_info', name: 'Saydyie') do
+      %ul.app-contact-list
+        %li
+          = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
+            %i.material-icons.app-contact-list__icon phone
+            %span.app-contact-list__primary-description
+              (503) 934-1113
+        %li
+          = link_to 'mailto:VictimServicesProgram@doc.state.or.us', class: 'app-contact-list__link' do
+            %i.material-icons.app-contact-list__icon email
+            %span.app-contact-list__primary-description
+              VictimServicesProgram@doc.state.or.us
+
+    = render_component 'dropdown', title: t('offender.what_talk_about', name: 'Saydyie') do
+      %p General public information about the offender
+      %p General information regarding misconducts the offender has received
+      %p Programs offered and general information on if the inmate is participating in programming
+      %p Location and institution movement of the offender
+      %p Resources for victims and victim family members
+      %p The victim service programs offered by the Oregon Department of Corrections
+      %p Questions about VINE
 

--- a/app/views/offenders/_who_prison_jail.html.haml
+++ b/app/views/offenders/_who_prison_jail.html.haml
@@ -1,0 +1,57 @@
+= render_component 'avatar_list_item',
+  caption: t('offender.robyn_title'),
+  name: t('offender.robyn'),
+  image: image_path('robyn.jpg')
+
+= render_component 'dropdown', title: t('offender.contact_info', name: 'Robyn') do
+  %ul.app-contact-list
+    %li
+      = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
+        %i.material-icons.app-contact-list__icon phone
+        %span.app-contact-list__primary-description
+          (503) 945-0907
+    %li
+      = link_to 'mailto:DLParoleBoardVictimNotify@doc.state.or.us', class: 'app-contact-list__link' do
+        %i.material-icons.app-contact-list__icon email
+        %span.app-contact-list__primary-description
+          DLParoleBoardVictimNotify@doc.state.or.us
+
+= render_component 'dropdown', title: t('offender.what_talk_about', name: 'Robyn') do
+  %p How to stay informed
+  %p What these notifications mean
+  %p Why the release date changes
+  %p Will there be a parole hearing I can speak at
+  %p Release plans and safety planning
+  %p Discuss terms of supervision and no contact orders
+  %p When and where an offender will be released
+  %p And more…
+
+.row
+.col.s10.offset-s1
+= render_component 'avatar_list_item',
+  caption: t('offender.saydyie_title'),
+  image: image_path('saydyie.jpg'),
+  name: t('offender.saydyie')
+
+= render_component 'dropdown', title: t('offender.contact_info', name: 'Saydyie') do
+  %ul.app-contact-list
+    %li
+      = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
+        %i.material-icons.app-contact-list__icon phone
+        %span.app-contact-list__primary-description
+          (503) 934-1113
+    %li
+      = link_to 'mailto:VictimServicesProgram@doc.state.or.us', class: 'app-contact-list__link' do
+        %i.material-icons.app-contact-list__icon email
+        %span.app-contact-list__primary-description
+          VictimServicesProgram@doc.state.or.us
+
+= render_component 'dropdown', title: t('offender.what_talk_about', name: 'Saydyie') do
+  %p General public information about the offender
+  %p General information regarding misconducts the offender has received
+  %p Programs offered and general information on if the inmate is participating in programming
+  %p Location and institution movement of the offender
+  %p Resources for victims and victim family members
+  %p The victim service programs offered by the Oregon Department of Corrections
+  %p Questions about VINE
+

--- a/app/views/offenders/_who_probation.html.haml
+++ b/app/views/offenders/_who_probation.html.haml
@@ -1,0 +1,2 @@
+.app-todo
+  Here are a list of people to talk to

--- a/app/views/offenders/_who_probation.html.haml
+++ b/app/views/offenders/_who_probation.html.haml
@@ -10,9 +10,17 @@
       caption: raw(t('offender.probation_who_ppo_title', phone: po_phone)),
       name: "#{locals[:po_first]} #{locals[:po_last]}"
 
+    = render_component 'dropdown', title: t('offender.what_talk_about', name: locals[:po_first]) do
+      .app-faq-item
+        = faq_format(t('offender.probation_who_ppo_what_about'))
+
 .row
   .col.s10.offset-s1
     = render_component 'avatar_list_item',
       image: image_path('chelsea.jpg'),
       caption: raw(t('offender.probation_who_call.caption')),
       name: t('offender.probation_who_call.name')
+
+    = render_component 'dropdown', title: t('offender.what_talk_about', name: 'Chelsea') do
+      .app-faq-item
+        = faq_format(t('offender.probation_who_chelsea_what_about'))

--- a/app/views/offenders/_who_probation.html.haml
+++ b/app/views/offenders/_who_probation.html.haml
@@ -1,10 +1,18 @@
 - po_phone = format_phone(locals[:po_phone])
 
-= render_component 'avatar_list_item',
-  caption: raw(t('offender.probation_who_ppo_title', phone: po_phone)),
-  name: "#{locals[:po_first]} #{locals[:po_last]}"
+%section.row
+  .col.s10.offset-s1
+    %h2.app-typography--header-2 Who can I talk to?
 
-= render_component 'avatar_list_item',
-  image: image_path('chelsea.jpg'),
-  caption: raw(t('offender.probation_who_call.caption')),
-  name: t('offender.probation_who_call.name')
+.row
+  .col.s10.offset-s1
+    = render_component 'avatar_list_item',
+      caption: raw(t('offender.probation_who_ppo_title', phone: po_phone)),
+      name: "#{locals[:po_first]} #{locals[:po_last]}"
+
+.row
+  .col.s10.offset-s1
+    = render_component 'avatar_list_item',
+      image: image_path('chelsea.jpg'),
+      caption: raw(t('offender.probation_who_call.caption')),
+      name: t('offender.probation_who_call.name')

--- a/app/views/offenders/_who_probation.html.haml
+++ b/app/views/offenders/_who_probation.html.haml
@@ -1,2 +1,10 @@
-.app-todo
-  Here are a list of people to talk to
+- po_phone = format_phone(locals[:po_phone])
+
+= render_component 'avatar_list_item',
+  caption: raw(t('offender.probation_who_ppo_title', phone: po_phone)),
+  name: "#{locals[:po_first]} #{locals[:po_last]}"
+
+= render_component 'avatar_list_item',
+  image: image_path('chelsea.jpg'),
+  caption: raw(t('offender.probation_who_call.caption')),
+  name: t('offender.probation_who_call.name')

--- a/app/views/offenders/index.html.haml
+++ b/app/views/offenders/index.html.haml
@@ -101,11 +101,12 @@
           - @grouped_results.each do |group|
             %tbody
               %tr.app-table__row--bordered{ data: { href: offender_path(group[:sid]) } }
-                %td= link_to group[:sid], offender_path(group[:sid])
+                - path = offender_offenders_path(group[:jurisdiction], group[:sid])
+                %td= link_to group[:sid], path
                 %td= @name_highlighter.highlight(group[:full_name])
                 %td= group[:dob]
               - group[:aliases].each do |name|
-                %tr{ data: { href: offender_path(group[:sid]) } }
+                %tr{ data: { href: path } }
                   %td
                   %td= @name_highlighter.highlight(name)
                   %td

--- a/app/views/offenders/index.html.haml
+++ b/app/views/offenders/index.html.haml
@@ -47,8 +47,8 @@
 
         .col.s10.offset-s1.m5
           .input-field
-            = f.text_field :last_name
-            = f.label :last_name, t('offender_search.last_name.label')
+            = f.text_field :dcj_last_name
+            = f.label :dcj_last_name, t('offender_search.last_name.label')
 
   .row
     .col.s10.offset-s1

--- a/app/views/offenders/show.html.haml
+++ b/app/views/offenders/show.html.haml
@@ -8,16 +8,19 @@
     %span.app-typography--body-1= @offender[:sid]
   .col.m5
     .app-typography--caption-above Offender Name
-    %span.app-typography--body-1= @offender[:name]
-.row.hide-on-med-and-down
-  .col.m5.offset-m1
-    .app-typography--caption-above Status
-    %span.app-typography--body-1= @offender[:status]
-  .col.m5
-    .app-typography--caption-above Offender Photo
     %span.app-typography--body-1
-      = link_to 'Show Photo', "http://docpub.state.or.us/OOS/imageLoader.jsp?idno=#{@offender[:sid]}", target: "_blank"
+      = @offender.include?(:name) ? @offender[:name] : "#{@offender[:first]} #{@offender[:last]}"
 .row.hide-on-med-and-down
+  - if @offender[:status]
+    .col.m5.offset-m1
+      .app-typography--caption-above Status
+      %span.app-typography--body-1= @offender[:status]
+  - if @offender[:jurisdiction] == :oregon
+    .col.m5
+      .app-typography--caption-above Offender Photo
+      %span.app-typography--body-1
+        = link_to 'Show Photo', "http://docpub.state.or.us/OOS/imageLoader.jsp?idno=#{@offender[:sid]}", target: "_blank"
+.row.hide-on-med-and-down{ class: ('hide' if @offender[:jurisdiction] != :oregon) }
   .col.m5.offset-m1
     .app-typography--caption-above Earliest Release Date (Not Finalized)
     %span.app-typography--body-1= @offender[:earliest_release_date]
@@ -32,16 +35,17 @@
 .row.hide-on-large-only
   .col.s10.offset-s1
     .app-typography--caption-above Offender Name
-    %span.app-typography--body-1= @offender[:name]
-.row.hide-on-large-only
+    %span.app-typography--body-1
+      = @offender.include?(:name) ? @offender[:name] : "#{@offender[:first]} #{@offender[:last]}"
+.row.hide-on-large-only{ class: ('hide' if @offender[:jurisdiction] != :oregon) }
   .col.s10.offset-s1
     .app-typography--caption-above Status
     %span.app-typography--body-1= @offender[:status]
-.row.hide-on-large-only
+.row.hide-on-large-only{ class: ('hide' if @offender[:jurisdiction] != :oregon) }
   .col.s10.offset-s1
     .app-typography--caption-above Location
     %span.app-typography--body-1= @offender[:location]
-.row.hide-on-large-only
+.row.hide-on-large-only{ class: ('hide' if @offender[:jurisdiction] != :oregon) }
   .col.s10.offset-s1
     .app-typography--caption-above Earliest Release Date (Not Finalized)
     %span.app-typography--body-1= @offender[:earliest_release_date]
@@ -50,90 +54,18 @@
   .col.s10.offset-s1
     %h2.app-typography--header-2 Frequently Asked Questions
 
-    - dropdown_key = 'faqs.prison_jail.dropdowns.how_earliest_release_date_change'
-    = render_component 'dropdown', title: t("#{dropdown_key}.title") do
-      .app-faq-item
-        = faq_format(t("#{dropdown_key}.body"))
-
-    = render_component 'dropdown', title: 'How can I stay informed about where the offender is?' do
-      %h3.app-typography--body-1
-        %strong Oregon VINE
-      %p
-        VINE is an automated notification system. For example, VINE will call,
-        text, and/or email you if there is a change in custody status.
-      = render_component 'button', to: vine_path(@offender[:sid]) do
-        VINE website
-        %i.material-icons open_in_new
-
-      %h3.app-typography--body-1
-        %strong Oregon Prison Release Notification
-      %p
-        The Oregon Parole Board can notify you 90 days prior to an inmate's
-        release and help you get a No Contact order added to an inmate's
-        conditions of Post-Prison Supervision.
-      - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
-      = render_component 'button', to: pps_form do
-        Sign Up Form
-        %i.material-icons open_in_new
+    - case @offender[:jurisdiction].to_sym
+    - when :oregon
+      = render 'offenders/faq_prison_jail'
+    - when :dcj
+      = render 'offenders/faq_probation'
 
 %section.row
   .col.s10.offset-s1
     %h2.app-typography--header-2 Who can I talk to?
 
-    = render_component 'avatar_list_item',
-      caption: t('offender.robyn_title'),
-      name: t('offender.robyn'),
-      image: image_path('robyn.jpg')
-
-    = render_component 'dropdown', title: t('offender.contact_info', name: 'Robyn') do
-      %ul.app-contact-list
-        %li
-          = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
-            %i.material-icons.app-contact-list__icon phone
-            %span.app-contact-list__primary-description
-              (503) 945-0907
-        %li
-          = link_to 'mailto:DLParoleBoardVictimNotify@doc.state.or.us', class: 'app-contact-list__link' do
-            %i.material-icons.app-contact-list__icon email
-            %span.app-contact-list__primary-description
-              DLParoleBoardVictimNotify@doc.state.or.us
-
-    = render_component 'dropdown', title: t('offender.what_talk_about', name: 'Robyn') do
-      %p How to stay informed
-      %p What these notifications mean
-      %p Why the release date changes
-      %p Will there be a parole hearing I can speak at
-      %p Release plans and safety planning
-      %p Discuss terms of supervision and no contact orders
-      %p When and where an offender will be released
-      %p And more…
-
-.row
-  .col.s10.offset-s1
-    = render_component 'avatar_list_item',
-      caption: t('offender.saydyie_title'),
-      image: image_path('saydyie.jpg'),
-      name: t('offender.saydyie')
-
-    = render_component 'dropdown', title: t('offender.contact_info', name: 'Saydyie') do
-      %ul.app-contact-list
-        %li
-          = link_to 'tel:503-945-0907', class: 'app-contact-list__link' do
-            %i.material-icons.app-contact-list__icon phone
-            %span.app-contact-list__primary-description
-              (503) 934-1113
-        %li
-          = link_to 'mailto:VictimServicesProgram@doc.state.or.us', class: 'app-contact-list__link' do
-            %i.material-icons.app-contact-list__icon email
-            %span.app-contact-list__primary-description
-              VictimServicesProgram@doc.state.or.us
-
-    = render_component 'dropdown', title: t('offender.what_talk_about', name: 'Saydyie') do
-      %p General public information about the offender
-      %p General information regarding misconducts the offender has received
-      %p Programs offered and general information on if the inmate is participating in programming
-      %p Location and institution movement of the offender
-      %p Resources for victims and victim family members
-      %p The victim service programs offered by the Oregon Department of Corrections
-      %p Questions about VINE
-
+    - case @offender[:jurisdiction].to_sym
+    - when :oregon
+      = render 'offenders/who_prison_jail'
+    - when :dcj
+      = render 'offenders/who_probation'

--- a/app/views/offenders/show.html.haml
+++ b/app/views/offenders/show.html.haml
@@ -60,13 +60,9 @@
     - when :dcj
       = render 'offenders/faq_probation'
 
-%section.row
-  .col.s10.offset-s1
-    %h2.app-typography--header-2 Who can I talk to?
-
-    - case @offender[:jurisdiction].to_sym
-    - when :oregon
-      = render 'offenders/who_prison_jail'
-    - when :dcj
-      = render 'offenders/who_probation',
-        locals: @offender.slice(:po_first, :po_last, :po_phone)
+- case @offender[:jurisdiction].to_sym
+- when :oregon
+  = render 'offenders/who_prison_jail'
+- when :dcj
+  = render 'offenders/who_probation',
+    locals: @offender.slice(:po_first, :po_last, :po_phone)

--- a/app/views/offenders/show.html.haml
+++ b/app/views/offenders/show.html.haml
@@ -68,4 +68,5 @@
     - when :oregon
       = render 'offenders/who_prison_jail'
     - when :dcj
-      = render 'offenders/who_probation'
+      = render 'offenders/who_probation',
+        locals: @offender.slice(:po_first, :po_last, :po_phone)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -5,10 +5,10 @@
     - @subscriptions.each do |subscription|
       %li
         = subscription.case_number
-        = link_to 'x', user_court_case_subscription_path(current_user, subscription.id), method: :delete
+        = link_to 'x', user_court_case_subscription_path(@current_user, subscription.id), method: :delete
 
     %h1.app-typography--header-1 Subscribe to a Case:
-    = form_for([current_user, CourtCaseSubscription.new]) do |f|
+    = form_for([@current_user, CourtCaseSubscription.new]) do |f|
       .input-field
         = f.text_field :case_number
         = f.label :case_number, 'Case Number'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,46 @@ en:
         Victims' Specialist, Department of Community Justice<br>
         (503) 988-2737
 
+    probation_who_chelsea_what_about: |
+      As an advocate, Chelsea can use the available offender information to help you create a safety plan tailored for your needs. For example:
+
+      Safety and safety-planning
+      <ul>
+        <li>How do I keep myself safe now? How do I explain this to my kids and keep them safe?</li>
+        <li>How can I be more safe as I prepare to leave an abusive relationship? How can I be more safe if I want to stay in the relationship?</li>
+        <li>What is the Address Confidentiality Program? Do I qualify?</li>
+      </ul>
+
+      Victim Rights
+      <ul>
+        <li>What rights do I have to protect me from my landlord or employer?</li>
+        <li>What rights do I have post-conviction? What information am I entitled to?</li>
+        <li>What is the Crime Victim's Compensation Program? Do I qualify?</li>
+      </ul>
+
+      Navigate the justice system
+      <ul>
+        <li>What if I am interested in Restorative Justice options, such as a "dialogue" with the offender?</li>
+        <li>How do I get a Protection Order (aka "Restraining Order")?</li>
+        <li>What's the difference between a Restraining Order and No Contact Order? Which is better?</li>
+        <li>How do I file for divorce or custody?</li>
+      </ul>
+
+      Support and referrals
+      <ul>
+        <li>Where can I get therapy or counseling? What support groups are available?</li>
+        <li>What if I need a domestic violence shelter? Homeless shelter? How do I access general housing assistance?</li>
+        <li>Where can I get legal advice or representation?</li>
+      </ul>
+
+      Emotional support
+      <ul>
+        <li>How do I explain what I am going through to friends and family?</li>
+        <li>How do I cope with this? When will I be "over" it?</li>
+        <li>My kids are struggling, how do I help them?</li>
+      </ul>
+
+
   offender_search:
     title: Look up an offender (in prison)
     by_name: 'By Name:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,28 @@ en:
       <strong>Probation Violation Hearings</strong>
       You can also <a href="https://multco.us/dcj/victims-services/webform/crime-victims-request-hearing-notification" target="_blank">sign up for Probation Violation hearing notification</a> to be informed if there is a probation violation hearing. If there is a hearing, you have the legal right to attend.
 
+    probation_who_ppo_title: |
+      Parole/Probation Officer, Department of Community Justice<br>
+      %{phone}
+    probation_who_ppo_what_about: |
+      As a parole/probation officer, Jennifer can talk to you about offender information and answer questions including:
+
+      <ul>
+        <li>What are the conditions of supervision? What do they mean to me?
+        <li>Whereabouts is the offender living? What areas should I avoid to avoid contact?
+        <li>Is the offender compliant with the conditions?
+        <li>What state of mind is the offender in?
+        <li>Is the offender making restitution payments?
+        <li>Is the offender compliant with treatment conditions?
+        <li>Other safety or general questions you might have
+      </ul>
+
+    probation_who_call:
+      name: 'Chelsea Penning'
+      caption: |
+        Victims' Specialist, Department of Community Justice<br>
+        (503) 988-2737
+
   offender_search:
     title: Look up an offender (in prison)
     by_name: 'By Name:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,18 @@ en:
     saydyie: 'Saydyie DeRosia'
     saydyie_title: 'Victim Services Coordinator, Oregon Department of Corrections'
     how_date_change: 'How might the release date date change?'
+    probation_faq_1_title: 'What is probation?'
+    probation_faq_1: |
+      There are a <a href="https://multco.us/dcj-adult/probation-parole-and-post-prison-supervision/standard-conditions-adult-probation-parole" target="_blank">set of general conditions of supervision</a> that apply in almost every case.
+
+      Sometimes there are special conditions of supervision that also apply (such as no-contact orders). To find out if a no-contact order applies in your case, you can call the Parole/Probation Officer.
+    probation_faq_2_title: 'How can I be notified about updates?'
+    probation_faq_2: |
+      <strong>Probation Status Updates</strong>
+      You can <a href="https://www.vinelink.com/#/home/site/38000" target="_blank">sign up for VINE notifications</a> to find out about any changes in supervision (for example, if the offender moves to another county) or if the offender is arrested.
+
+      <strong>Probation Violation Hearings</strong>
+      You can also <a href="https://multco.us/dcj/victims-services/webform/crime-victims-request-hearing-notification" target="_blank">sign up for Probation Violation hearing notification</a> to be informed if there is a probation violation hearing. If there is a hearing, you have the legal right to attend.
 
   offender_search:
     title: Look up an offender (in prison)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  resources :offenders, only: %i[show index] do
+  resources :offenders, only: %i[index] do
     collection do
+      get '/:jurisdiction/:id', action: :show, as: :offender
       post :search
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :offenders, only: %i[index] do
     collection do
+      get '/:id', to: redirect('/offenders/oregon/%{id}')
       get '/:jurisdiction/:id', action: :show, as: :offender
       post :search
     end

--- a/spec/controllers/offenders_controller_spec.rb
+++ b/spec/controllers/offenders_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 OFFENDER_FIXTURE = {
+  jurisdiction: :oregon,
   sid: '11273355',
   age: '41',
   gender: 'Female',
@@ -23,6 +24,17 @@ OFFENDER_FIXTURE = {
     "15CR44118/03,MARI,DELIV,METH,NEAR,SCHOOL,Inmate,Sentence,12/10/2015,-"
   ],
   num_offenses: 4,
+}
+
+DCJ_OFFENDER = {
+  jurisdiction: :dcj,
+  first: 'John',
+  last: 'Wilhite',
+  sid: 20130142,
+  dob: Date.parse('1980-01-01'),
+  po_first: 'FrankThe',
+  po_last: 'POPerson',
+  po_phone: '503-555-1234 ext 12345',
 }
 
 RSpec.describe OffendersController do
@@ -49,7 +61,7 @@ RSpec.describe OffendersController do
 
     describe 'with search by name' do
       let(:params) { { offender: { first_name: 'Tom', last_name: 'Dooner' } } }
-      let(:results) { [{ sid: 123456, first: 'Tom', last: 'Dooner' }] }
+      let(:results) { [{ sid: 123456, jurisdiction: :oregon, first: 'Tom', last: 'Dooner' }] }
 
       before do
         allow(OffenderScraper).to receive(:search_by_name).and_return(results)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,6 +18,10 @@ describe ApplicationHelper do
     it 'formats a phone number as intended' do
       expect(helper.format_phone('+11234567890')).to eq('(123) 456-7890')
     end
+
+    it 'formats a phone number with an extension' do
+      expect(helper.format_phone('503-555-1234 ext 88449')).to eq('(503) 555-1234 ext 88449')
+    end
   end
 
   describe '#link_path_for_offender_or_search' do

--- a/spec/lib/offender_grouper_spec.rb
+++ b/spec/lib/offender_grouper_spec.rb
@@ -1,23 +1,25 @@
 require 'rails_helper'
 
 RESULTS = [
-  { sid: '16077966', first: 'AARON', middle: '', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'M', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN-ANDRESON', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICAHEL', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICHEAL', last: 'BROWN', dob: '09/1986' },
-  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986' },
-  { sid: '19046875', first: 'AARON', middle: '', last: 'BROWN', dob: '04/1991' },
-  { sid: '19046875', first: 'AARON', middle: 'ARTHUR', last: 'BROWN', dob: '04/1991' },
-  { sid: '19046875', first: 'AARON', middle: 'A', last: 'BROWN', dob: '04/1991' },
-  { sid: '19046875', first: 'AARON', middle: '', last: 'BROWN', dob: '04/1991' },
-  { sid: '19046875', first: 'AARON', middle: 'KARMA', last: 'BROWN', dob: '04/1991' },
+  { sid: '16077966', first: 'AARON', middle: '', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'M', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN-ANDRESON', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICAHEL', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICHEAL', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '16077966', first: 'AARON', middle: 'MICHAEL', last: 'BROWN', dob: '09/1986', jurisdiction: :oregon },
+  { sid: '19046875', first: 'AARON', middle: '', last: 'BROWN', dob: '04/1991', jurisdiction: :oregon },
+  { sid: '19046875', first: 'AARON', middle: 'ARTHUR', last: 'BROWN', dob: '04/1991', jurisdiction: :oregon },
+  { sid: '19046875', first: 'AARON', middle: 'A', last: 'BROWN', dob: '04/1991', jurisdiction: :oregon },
+  { sid: '19046875', first: 'AARON', middle: '', last: 'BROWN', dob: '04/1991', jurisdiction: :oregon },
+  { sid: '19046875', first: 'AARON', middle: 'KARMA', last: 'BROWN', dob: '04/1991', jurisdiction: :oregon },
 ]
 
 describe OffenderGrouper do
-  subject { described_class.new(RESULTS) }
+  let(:offenders) { RESULTS }
+
+  subject { described_class.new(offenders) }
 
   describe '#each_group' do
     it 'returns an enumerable of groups' do
@@ -45,6 +47,23 @@ describe OffenderGrouper do
         'Aaron Micheal Brown',
         'Aaron Michael Brown',
       ])
+    end
+
+    context 'with an offender in a different jurisdiction' do
+      let(:offenders) do
+        super().tap do |offenders|
+          offender = offenders[-1].dup
+          offender[:jurisdiction] = :dcj
+
+          offenders.push(offender)
+        end
+      end
+
+      it 'raises an error if the SID is the same' do
+        expect(Raven).to receive(:capture_message).once.with(/jurisdiction/i)
+
+        subject.each_group.to_a
+      end
     end
   end
 

--- a/spec/lib/offender_scraper_spec.rb
+++ b/spec/lib/offender_scraper_spec.rb
@@ -1,6 +1,26 @@
 require 'rails_helper'
 
 describe OffenderScraper do
+  describe '.search_by_name' do
+    let(:first_name) { 'Foo' }
+    let(:last_name) { 'BarBaz' }
+    let(:fake_result) do
+      { sid: '1234', first: first_name, middle: '', last: last_name, dob: '01/1991' }
+    end
+
+    before do
+      allow_any_instance_of(OosMechanizer::Searcher).to receive(:each_result)
+        .with(first_name: first_name, last_name: last_name)
+        .and_return([fake_result])
+    end
+
+    subject { OffenderScraper.search_by_name(first_name, last_name) }
+
+    it 'returns results with a jurisdiction' do
+      expect(subject[0][:jurisdiction]).to eq(:oregon)
+    end
+  end
+
   describe '.offender_details' do
     # since stubbing all the mechanize stuff is going to be difficult, we can
     # just stub the scrap method to test the surrounding logic

--- a/spec/lib/offender_scraper_spec.rb
+++ b/spec/lib/offender_scraper_spec.rb
@@ -7,6 +7,8 @@ describe OffenderScraper do
     let(:fake_data) { { sid: '1234', name: 'Foo bar' } }
 
     before do
+      OffenderSearchCache.destroy_all # TODO: why no transactional fixtures?
+
       allow(OffenderScraper).to receive(:fetch_offender_details).and_return(fake_data)
     end
 


### PR DESCRIPTION
This is the initial work to bring the number of data sources we search for offenders from one to two. (Always the hardest!)

To do this I introduce a concept of "jurisdiction" to which the offenders belong. Each "jurisdiction" is likely to have its own search restrictions, for example we cannot search DCJ only by SID (we must supplement it with either DOB or Last Name).

The URL helper name `offender_offenders_path` is really awful, I want to change that to something that makes more sense.